### PR TITLE
Implement persistent hashing of rule parameters

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -3,3 +3,9 @@ id = "119b4c09-afc4-4968-bc45-7619c9df0a4f"
 type = "feature"
 description = "Add `HashSupport(default)` argument and attribute"
 author = "@NiklasRosenstein"
+
+[[entries]]
+id = "d25fe1fb-c9d0-4e3c-afcf-18d0d5eac1b2"
+type = "breaking change"
+description = "Implement persistent hashing."
+author = "@NiklasRosenstein"

--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -3,9 +3,11 @@ id = "119b4c09-afc4-4968-bc45-7619c9df0a4f"
 type = "feature"
 description = "Add `HashSupport(default)` argument and attribute"
 author = "@NiklasRosenstein"
+pr = "https://github.com/NiklasRosenstein/python-adjudicator/pull/2"
 
 [[entries]]
 id = "d25fe1fb-c9d0-4e3c-afcf-18d0d5eac1b2"
 type = "breaking change"
 description = "Implement persistent hashing."
 author = "@NiklasRosenstein"
+pr = "https://github.com/NiklasRosenstein/python-adjudicator/pull/2"

--- a/src/adjudicator/HashSupport.py
+++ b/src/adjudicator/HashSupport.py
@@ -1,4 +1,8 @@
-from typing import Any, Callable
+import hashlib
+import sys
+from collections.abc import Sequence
+from types import NoneType
+from typing import Any, Callable, Mapping
 
 Hasher = Callable[[Any], int]
 
@@ -6,11 +10,19 @@ Hasher = Callable[[Any], int]
 class HashSupport:
     """
     A helper class that supports in hashing objects. Usually it just defaults to the native #hash() function, but
-    some otherwise unhashable types can be made hashable by providing a custom hash function.
+    some otherwise unhashable types can be made hashable by providing a custom hash function. By default, it uses
+    the #persistent_hash() function, which returns the same hash for the same object across separate Python program
+    executions, however with limited built-in support for types.
+
+    :param permit_not_persistent_hashing: If `True`, the #persistent_hash() function will fall back to the native
+        #hash() function if it cannot hash the given object, resulting in a non-persistent hash. If `False`, it will
+        # raise a `NotImplementedError` instead.
     """
 
-    def __init__(self, default: Hasher = hash) -> None:
-        self.default = hash
+    def __init__(self, permit_not_persistent_hashing: bool = False) -> None:
+        self.default: Hasher = lambda obj: persistent_hash(
+            obj, self, fallback=hash if permit_not_persistent_hashing else None
+        )
         self._custom_hashers: dict[type, Hasher] = {}
         self._fallback_hashers: list[Hasher] = []
 
@@ -35,9 +47,10 @@ class HashSupport:
         Hash the given object.
         """
 
-        hash_func = self._custom_hashers.get(type(obj))
-        if hash_func is not None:
-            return hash_func(obj)
+        for base in type(obj).__mro__:
+            hash_func = self._custom_hashers.get(base)
+            if hash_func is not None:
+                return hash_func(obj)
 
         for hash_func in self._fallback_hashers:
             try:
@@ -48,3 +61,69 @@ class HashSupport:
                 return result
 
         return self.default(obj)
+
+
+def persistent_hash(obj: Any, recurse: Hasher, algorithm: str = "blake2b", fallback: Hasher | None = None) -> int:
+    """
+    A hash function that returns the same hash for the same object across separate Python program executions.
+    """
+
+    hasher = hashlib.new(algorithm)
+
+    def hash_obj(obj: Any) -> None:
+        hasher.update(type(obj).__name__.encode("utf-8"))
+        match obj:
+            case type():
+                hasher.update(obj.__name__.encode("utf-8"))
+                hasher.update(b";")
+                return
+            case int():
+                # TODO: Support big integers?
+                hasher.update(obj.to_bytes(8, "little", signed=True))
+                return
+            case str():
+                hasher.update(obj.encode("utf-8"))
+                return
+            case bytes():
+                hasher.update(obj)
+                return
+            case bool():
+                hasher.update(obj.to_bytes(1, "little"))
+                return
+            case NoneType():
+                return
+            case Sequence():
+                hasher.update(b"[")
+                for item in obj:
+                    hasher.update(recurse(item).to_bytes(8, "little", signed=True))
+                hasher.update(b"]")
+                return
+        if isinstance(obj, Mapping):
+            hasher.update(b"m{")
+            for key, value in obj.items():
+                hasher.update(recurse(key).to_bytes(8, "little", signed=True))
+                hasher.update(b",")
+                hasher.update(recurse(value).to_bytes(8, "little", signed=True))
+                hasher.update(b";")
+            hasher.update(b"}")
+            return
+        if hasattr(obj, "__dataclass_fields__"):
+            hasher.update(b"D{")
+            for field in obj.__dataclass_fields__.values():
+                hasher.update(recurse(field.name).to_bytes(8, "little", signed=True))
+                hasher.update(b",")
+                hasher.update(recurse(getattr(obj, field.name)).to_bytes(8, "little", signed=True))
+                hasher.update(b";")
+            hasher.update(b"}")
+            return
+        if hasattr(obj, "__consistent_hash__"):
+            hasher.update(obj.__consistent_hash__().to_bytes(8, "little", signed=True))
+            return
+        if fallback:
+            hasher.update(hash(obj).to_bytes(8, "little", signed=True))
+        else:
+            raise NotImplementedError(f"Cannot consistent-hash object of type {type(obj)}")
+
+    hash_obj(obj)
+    digest = hasher.digest()
+    return int.from_bytes(digest, "little", signed=True) % sys.maxsize

--- a/src/adjudicator/HashSupport.py
+++ b/src/adjudicator/HashSupport.py
@@ -116,8 +116,8 @@ def persistent_hash(obj: Any, recurse: Hasher, algorithm: str = "blake2b", fallb
                 hasher.update(b";")
             hasher.update(b"}")
             return
-        if hasattr(obj, "__consistent_hash__"):
-            hasher.update(obj.__consistent_hash__().to_bytes(8, "little", signed=True))
+        if hasattr(obj, "__persistent_hash__"):
+            hasher.update(obj.__persistent_hash__().to_bytes(8, "little", signed=True))
             return
         if fallback:
             hasher.update(hash(obj).to_bytes(8, "little", signed=True))

--- a/src/adjudicator/HashSupport.py
+++ b/src/adjudicator/HashSupport.py
@@ -1,6 +1,7 @@
 import hashlib
 import sys
 from collections.abc import Sequence
+from functools import partial
 from types import NoneType
 from typing import Any, Callable, Mapping
 
@@ -20,8 +21,10 @@ class HashSupport:
     """
 
     def __init__(self, permit_not_persistent_hashing: bool = False) -> None:
-        self.default: Hasher = lambda obj: persistent_hash(
-            obj, self, fallback=hash if permit_not_persistent_hashing else None
+        self.default: Hasher = partial(
+            persistent_hash,
+            recurse=self,
+            fallback=hash if permit_not_persistent_hashing else None,
         )
         self._custom_hashers: dict[type, Hasher] = {}
         self._fallback_hashers: list[Hasher] = []

--- a/src/adjudicator/HashSupport_test.py
+++ b/src/adjudicator/HashSupport_test.py
@@ -1,0 +1,44 @@
+import subprocess as sp
+import sys
+from dataclasses import dataclass
+from pickle import dumps
+from typing import Any, Literal
+
+from adjudicator.HashSupport import HashSupport
+
+
+def hash_here_and_there(obj: Any, method: Literal["builtin", "persistent"]) -> tuple[int, int]:
+    match method:
+        case "builtin":
+            hasher = hash
+            hasher_expr = "hasher = hash"
+        case "persistent":
+            hasher = HashSupport()
+            hasher_expr = "from adjudicator.HashSupport import HashSupport; hasher = HashSupport()"
+
+    here = hasher(obj)
+
+    code = f"{hasher_expr}; import pickle; print(hasher(pickle.loads({dumps(obj)!r})))"
+    there = int(sp.run([sys.executable, "-c", code], capture_output=True, text=True, check=True).stdout)
+
+    return here, there
+
+
+def assert_hash_is_persistent(obj: Any, skip_builtin: bool = False) -> None:
+    assert hash_here_and_there(obj, "persistent") == hash_here_and_there(obj, "persistent")
+    if not skip_builtin:
+        assert hash_here_and_there(obj, "builtin") != hash_here_and_there(obj, "builtin")
+
+
+@dataclass(frozen=True)
+class MyDataclass:
+    foo: str
+    bar: str
+
+
+def test__persistent_hashing() -> None:
+    assert_hash_is_persistent("foobar!")
+    assert_hash_is_persistent(("foo", "bar", "baz"))
+    assert_hash_is_persistent(["hello world"], skip_builtin=True)
+    assert_hash_is_persistent({"foo": "bar"}, skip_builtin=True)
+    assert_hash_is_persistent(MyDataclass("foo", "bar"))

--- a/src/adjudicator/Params.py
+++ b/src/adjudicator/Params.py
@@ -122,7 +122,7 @@ information.
         return self._hash
 
     #: If we have a consistent hasher, then the __hash__ method yields a consistent hash already.
-    __consistent_hash__ = __hash__
+    __persistent_hash__ = __hash__
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({', '.join(map(repr, self._params.values()))})"

--- a/src/adjudicator/Params.py
+++ b/src/adjudicator/Params.py
@@ -121,6 +121,9 @@ information.
             self._hash = self._hasher(tuple(sorted(map(self._hasher, self._params.values()))))
         return self._hash
 
+    #: If we have a consistent hasher, then the __hash__ method yields a consistent hash already.
+    __consistent_hash__ = __hash__
+
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({', '.join(map(repr, self._params.values()))})"
 
@@ -189,3 +192,7 @@ information.
         """
 
         return Params(self, hasher=hasher)
+
+    @property
+    def hasher(self) -> Hasher:
+        return self._hasher


### PR DESCRIPTION
This PR adds changes the `HashSupport` class to hash objects persistently by default. Persistent hashes stay the same for the same object across multiple executions of the same Python program, unlike the built-in `hash()` function which is only guaranteed to be consistent within the same process.

The `persistent_hash()` function only supports a subset of built-in types. On the other hand, it does support hashing mutable lists and mappings. Special support for persistent hashing can be added by registered a type-specific handler using `HashSupport.register()` or a fallback with `HashSupport.fallback()`.

Hashers registered with `HashSupport.register()` now also apply to all subtypes.